### PR TITLE
send response as a byte array rather than a byte for the xfer function

### DIFF
--- a/usbiss/__init__.py
+++ b/usbiss/__init__.py
@@ -144,7 +144,9 @@ class USBISS(object):
             status = response[0]
             if status == 0:
                 raise RuntimeError('USB-ISS: Transmission Error')
-            decoded = [struct.unpack('B', response[i+1])[0] for i in range(0, len(data))]
+
+            decoded = [struct.unpack('B', response[i + 1: i + 2])[0] for i in range(0, len(data))]
+            
             return decoded
         else:
             raise RuntimeError('USB-ISS: Transmission Error: No bytes received!')


### PR DESCRIPTION
Converted the structured byte to a byte array to allow for compatibility with Python3+. It has been verified to work using Raspian on a Raspberry Pi 2 with both Python2.7 and Python3.2
